### PR TITLE
Fix generation of credentials sharing URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-angular-credential ChangeLog
 
+### Fixed
+- Fix generation of credentials sharing URL.
+
 ## 2.2.2 - 2016-08-11
 
 ### Fixed

--- a/bedrock/config.js
+++ b/bedrock/config.js
@@ -32,4 +32,10 @@ module.exports = function(bedrock) {
   } else {
     vars['bedrock-angular-credential'].credentialsBasePath = '';
   }
+  if('identity-http' in bedrock.config) {
+    vars['bedrock-angular-credential'].identityBasePath =
+      bedrock.config['identity-http'].basePath || '';
+  } else {
+    vars['bedrock-angular-credential'].identityBasePath = '';
+  }
 };

--- a/credentials-list-directive.js
+++ b/credentials-list-directive.js
@@ -11,7 +11,7 @@ define(['angular', 'jsonld'], function(angular, jsonld) {
 'use strict';
 
 /* @ngInject */
-function factory(brAlertService, brCredentialService, config) {
+function factory($location, brAlertService, brCredentialService, config) {
   return {
     restrict: 'E',
     scope: {
@@ -30,9 +30,17 @@ function factory(brAlertService, brCredentialService, config) {
       credentials: {loading: true}
     };
 
-    model.credentialsShareUrl =
-      config.data.baseUri + config.data.identity.baseUri + '/' +
-      encodeURI(scope.identity.sysSlug);
+    if(scope.identity.sysSlug) {
+      // enough info available to generate URL
+      model.credentialsShareUrl =
+        config.data.baseUri +
+        config.data['bedrock-angular-credential'].identityBasePath + '/' +
+        encodeURI(scope.identity.sysSlug);
+    } else {
+      // default to location
+      // FIXME: this requires the component be used at a proper identity URL
+      model.credentialsShareUrl = config.data.baseUri + $location.url();
+    }
     scope.$watch('identity', function(identity) {
       brCredentialService.setIdentity(identity);
       _credentialTypeUpdated(scope.credentialType);


### PR DESCRIPTION
- Get identity base path from config.
- Use sysSlug if available.
- Default to location. This current only works if component is used at a
  proper URL.
